### PR TITLE
feat: Binary syscall bypass through VDSO

### DIFF
--- a/sysdeps/unix/sysv/linux/Makefile
+++ b/sysdeps/unix/sysv/linux/Makefile
@@ -55,6 +55,7 @@ endif
 
 ifeq ($(subdir),misc)
 sysdep_routines += \
+  uk_vsyscall \
   adjtimex \
   clock_adjtime \
   clone \

--- a/sysdeps/unix/sysv/linux/uk_vsyscall.c
+++ b/sysdeps/unix/sysv/linux/uk_vsyscall.c
@@ -1,0 +1,9 @@
+#include <dl-vdso.h>
+
+void *__kernel_vsyscall = 0;
+
+void uk_init_vsyscall(void) __attribute__((constructor));
+
+void uk_init_vsyscall(void) {
+	__kernel_vsyscall = dl_vdso_vsym("__kernel_vsyscall");
+}

--- a/sysdeps/unix/sysv/linux/x86_64/sysdep.h
+++ b/sysdeps/unix/sysv/linux/x86_64/sysdep.h
@@ -238,15 +238,21 @@
 #define INTERNAL_SYSCALL_NCS(number, nr, args...)			\
 	internal_syscall##nr (number, args)
 
+extern void *__kernel_vsyscall;
+
 #undef internal_syscall0
 #define internal_syscall0(number, dummy...)				\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long))__kernel_vsyscall)(number);  \
+    } else {                              \
     asm volatile (							\
     "syscall\n\t"							\
     : "=a" (resultvar)							\
     : "0" (number)							\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -254,6 +260,9 @@
 #define internal_syscall1(number, arg1)					\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long))__kernel_vsyscall)(number, (long)(arg1));  \
+    } else {                              \
     TYPEFY (arg1, __arg1) = ARGIFY (arg1);			 	\
     register TYPEFY (arg1, _a1) asm ("rdi") = __arg1;			\
     asm volatile (							\
@@ -261,6 +270,7 @@
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1)						\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -268,6 +278,9 @@
 #define internal_syscall2(number, arg1, arg2)				\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long, long))__kernel_vsyscall)(number, (long)(arg1), (long)(arg2));  \
+    } else {                              \
     TYPEFY (arg2, __arg2) = ARGIFY (arg2);			 	\
     TYPEFY (arg1, __arg1) = ARGIFY (arg1);			 	\
     register TYPEFY (arg2, _a2) asm ("rsi") = __arg2;			\
@@ -277,6 +290,7 @@
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2)				\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -284,6 +298,9 @@
 #define internal_syscall3(number, arg1, arg2, arg3)			\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long, long, long))__kernel_vsyscall)(number, (long)(arg1), (long)(arg2), (long)(arg3));  \
+    } else {                              \
     TYPEFY (arg3, __arg3) = ARGIFY (arg3);			 	\
     TYPEFY (arg2, __arg2) = ARGIFY (arg2);			 	\
     TYPEFY (arg1, __arg1) = ARGIFY (arg1);			 	\
@@ -295,6 +312,7 @@
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3)			\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -302,6 +320,9 @@
 #define internal_syscall4(number, arg1, arg2, arg3, arg4)		\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long, long, long, long))__kernel_vsyscall)(number, (long)(arg1), (long)(arg2), (long)(arg3), (long)(arg4));  \
+    } else {                              \
     TYPEFY (arg4, __arg4) = ARGIFY (arg4);			 	\
     TYPEFY (arg3, __arg3) = ARGIFY (arg3);			 	\
     TYPEFY (arg2, __arg2) = ARGIFY (arg2);			 	\
@@ -315,6 +336,7 @@
     : "=a" (resultvar)							\
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4)		\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -322,6 +344,9 @@
 #define internal_syscall5(number, arg1, arg2, arg3, arg4, arg5)	\
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long, long, long, long, long))__kernel_vsyscall)(number, (long)(arg1), (long)(arg2), (long)(arg3), (long)(arg4), (long)(arg5));  \
+    } else {                              \
     TYPEFY (arg5, __arg5) = ARGIFY (arg5);			 	\
     TYPEFY (arg4, __arg4) = ARGIFY (arg4);			 	\
     TYPEFY (arg3, __arg3) = ARGIFY (arg3);			 	\
@@ -338,6 +363,7 @@
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4),		\
       "r" (_a5)								\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 
@@ -345,6 +371,9 @@
 #define internal_syscall6(number, arg1, arg2, arg3, arg4, arg5, arg6) \
 ({									\
     unsigned long int resultvar;					\
+    if (__glibc_likely(!!__kernel_vsyscall)) {              \
+      resultvar = ((long(*)(long, long, long, long, long, long, long))__kernel_vsyscall)(number, (long)(arg1), (long)(arg2), (long)(arg3), (long)(arg4), (long)(arg5), (long)(arg6));  \
+    } else {                              \
     TYPEFY (arg6, __arg6) = ARGIFY (arg6);			 	\
     TYPEFY (arg5, __arg5) = ARGIFY (arg5);			 	\
     TYPEFY (arg4, __arg4) = ARGIFY (arg4);			 	\
@@ -363,6 +392,7 @@
     : "0" (number), "r" (_a1), "r" (_a2), "r" (_a3), "r" (_a4),		\
       "r" (_a5), "r" (_a6)						\
     : "memory", REGISTERS_CLOBBERED_BY_SYSCALL);			\
+    }             \
     (long int) resultvar;						\
 })
 


### PR DESCRIPTION
Glibc utilizes the `INTERNAL_SYSCALL` macro to perform system calls. Syscalls with varying numbers of parameters are further dispatched to implementations like `internal_syscall0`, `internal_syscall1`, and so on. These implementations employ the `syscall` instruction for binary syscalls. To bypass binary syscalls, we extract the `__kernel_vsyscall` symbol from VDSO and replace the `syscall` instruction with a direct call to the kernel functions.

Note that during the initialization process of glibc, certain syscalls will be used. However, at this point, the `__kernel_vsyscall` symbol has not yet been extracted. It's also possible that the kernel could not provide this interface. In such cases, the `__kernel_vsyscall` pointer remains at its default value of `NULL`, and glibc will continue to use binary syscalls.

Since we do not support syscalls with cancellation points (syscall_cp), we merely map them to regular syscalls.

This should be used with `app-elfloader`, and only works for dynamic-linked applications. Testcases are also provided by the actual applications on the `app-elfloader`.